### PR TITLE
:art: refactor to use lib.addCommand

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,6 +6,7 @@ version '2.0.0'
 
 shared_scripts {
 	'config.lua',
+	'@ox_lib/init.lua',
 	'@qb-core/shared/locale.lua',
 	'locales/en.lua'
 }

--- a/server/server.lua
+++ b/server/server.lua
@@ -169,7 +169,7 @@ end)
 -- COMMANDS
 lib.addCommand('freezetime', {
 	help = Lang:t('help.freezecommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     local newstate = setTimeFreeze()
     if newstate then TriggerClientEvent('QBCore:Notify', source, Lang:t('time.frozenc'))
@@ -178,7 +178,7 @@ end)
 
 lib.addCommand('freezeweather', {
 	help = Lang:t('help.freezecommand'),
-    restricted = 'admin',
+    restricted = 'group.admin',
     },
 function(source)
     local newstate = setDynamicWeather()
@@ -191,7 +191,7 @@ lib.addCommand('weather', {
 	params = {
 		{ name = Lang:t('help.weathertype'), type = 'string', help = Lang:t('help.availableweather') },
 	},
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source, args)
     local weatherType = args[Lang:t('help.weathertype')]
     local success = setWeather(weatherType)
@@ -201,7 +201,7 @@ end)
 
 lib.addCommand('blackout', {
 	help = Lang:t('help.blackoutcommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     local newstate = setBlackout()
     if newstate then TriggerClientEvent('QBCore:Notify', source, Lang:t('blackout.enabledc'))
@@ -210,7 +210,7 @@ end)
 
 lib.addCommand('morning', {
 	help = Lang:t('help.morningcommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     setTime(9, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.morning'))
@@ -218,7 +218,7 @@ end)
 
 lib.addCommand('noon', {
 	help = Lang:t('help.nooncommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     setTime(12, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.noon'))
@@ -226,7 +226,7 @@ end)
 
 lib.addCommand('evening', {
 	help = Lang:t('help.eveningcommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     setTime(18, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.evening'))
@@ -234,7 +234,7 @@ end)
 
 lib.addCommand('night', {
 	help = Lang:t('help.nightcommand'),
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source)
     setTime(23, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.night'))
@@ -246,7 +246,7 @@ lib.addCommand('time', {
         { name = Lang:t('help.timehname'), help =Lang:t('help.timeh') },
         { name = Lang:t('help.timemname'), help = Lang:t('help.timem') }
 	},
-	restricted = 'admin',
+	restricted = 'group.admin',
 }, function(source, args)
     local hour = args[Lang:t('help.timehname')]
     local minute = args[Lang:t('help.timemname')]

--- a/server/server.lua
+++ b/server/server.lua
@@ -167,55 +167,94 @@ RegisterNetEvent('qb-weathersync:server:toggleDynamicWeather', function(state)
 end)
 
 -- COMMANDS
-QBCore.Commands.Add('freezetime', Lang:t('help.freezecommand'), {}, false, function(source)
+lib.addCommand('freezetime', {
+	help = Lang:t('help.freezecommand'),
+	restricted = 'admin',
+}, function(source)
     local newstate = setTimeFreeze()
     if newstate then TriggerClientEvent('QBCore:Notify', source, Lang:t('time.frozenc'))
     else TriggerClientEvent('QBCore:Notify', source, Lang:t('time.unfrozenc')) end
-end, 'admin')
+end)
 
-QBCore.Commands.Add('freezeweather', Lang:t('help.freezeweathercommand'), {}, false, function(source)
+lib.addCommand('freezeweather', {
+	help = Lang:t('help.freezecommand'),
+    restricted = 'admin',
+    },
+function(source)
     local newstate = setDynamicWeather()
     if newstate then TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.enabled'))
     else TriggerClientEvent('QBCore:Notify', source, Lang:t('dynamic_weather.disabled')) end
-end, 'admin')
+end)
 
-QBCore.Commands.Add('weather', Lang:t('help.weathercommand'), {{name = Lang:t('help.weathertype'), help = Lang:t('help.availableweather')}}, true, function(source, args)
-    local success = setWeather(args[1])
-    if success then TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.willchangeto', {value = string.lower(args[1])}))
+lib.addCommand('weather', {
+	help = Lang:t('help.weathercommand'),
+	params = {
+		{ name = Lang:t('help.weathertype'), type = 'string', help = Lang:t('help.availableweather') },
+	},
+	restricted = 'admin',
+}, function(source, args)
+    local weatherType = args[Lang:t('help.weathertype')]
+    local success = setWeather(weatherType)
+    if success then TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.willchangeto', {value = string.lower(weatherType)}))
     else TriggerClientEvent('QBCore:Notify', source, Lang:t('weather.invalidc'), 'error') end
-end, 'admin')
+end)
 
-QBCore.Commands.Add('blackout', Lang:t('help.blackoutcommand'), {}, false, function(source)
+lib.addCommand('blackout', {
+	help = Lang:t('help.blackoutcommand'),
+	restricted = 'admin',
+}, function(source)
     local newstate = setBlackout()
     if newstate then TriggerClientEvent('QBCore:Notify', source, Lang:t('blackout.enabledc'))
     else TriggerClientEvent('QBCore:Notify', source, Lang:t('blackout.disabledc')) end
-end, 'admin')
+end)
 
-QBCore.Commands.Add('morning', Lang:t('help.morningcommand'), {}, false, function(source)
+lib.addCommand('morning', {
+	help = Lang:t('help.morningcommand'),
+	restricted = 'admin',
+}, function(source)
     setTime(9, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.morning'))
-end, 'admin')
+end)
 
-QBCore.Commands.Add('noon', Lang:t('help.nooncommand'), {}, false, function(source)
+lib.addCommand('noon', {
+	help = Lang:t('help.nooncommand'),
+	restricted = 'admin',
+}, function(source)
     setTime(12, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.noon'))
-end, 'admin')
+end)
 
-QBCore.Commands.Add('evening', Lang:t('help.eveningcommand'), {}, false, function(source)
+lib.addCommand('evening', {
+	help = Lang:t('help.eveningcommand'),
+	restricted = 'admin',
+}, function(source)
     setTime(18, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.evening'))
-end, 'admin')
+end)
 
-QBCore.Commands.Add('night', Lang:t('help.nightcommand'), {}, false, function(source)
+lib.addCommand('night', {
+	help = Lang:t('help.nightcommand'),
+	restricted = 'admin',
+}, function(source)
     setTime(23, 0)
     TriggerClientEvent('QBCore:Notify', source, Lang:t('time.night'))
-end, 'admin')
+end)
 
-QBCore.Commands.Add('time', Lang:t('help.timecommand'), {{ name=Lang:t('help.timehname'), help=Lang:t('help.timeh') }, { name=Lang:t('help.timemname'), help=Lang:t('help.timem') }}, true, function(source, args)
-    local success = setTime(args[1], args[2])
-    if success then TriggerClientEvent('QBCore:Notify', source, Lang:t('time.changec', {value = args[1] .. ':' .. (args[2] or "00")}))
+lib.addCommand('time', {
+	help = Lang:t('help.timecommand'),
+	params = {
+        { name = Lang:t('help.timehname'), help =Lang:t('help.timeh') },
+        { name = Lang:t('help.timemname'), help = Lang:t('help.timem') }
+	},
+	restricted = 'admin',
+}, function(source, args)
+    local hour = args[Lang:t('help.timehname')]
+    local minute = args[Lang:t('help.timemname')]
+    local success = setTime(hour, minute)
+    if success then TriggerClientEvent('QBCore:Notify', source, Lang:t('time.changec', {value = hour .. ':' .. (minute or "00")}))
     else TriggerClientEvent('QBCore:Notify', source, Lang:t('time.invalidc'), 'error') end
-end, 'admin')
+end)
+
 
 -- THREAD LOOPS
 CreateThread(function()


### PR DESCRIPTION
## Description

Switches commands from using `QBCore.Commands.Add()` to `lib.addCommand()`

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
